### PR TITLE
Split README

### DIFF
--- a/POSTGRES.md
+++ b/POSTGRES.md
@@ -1,0 +1,30 @@
+# Postgres Instructions
+
+## Getting a database dump
+
+Use `pg_dump` in "schema-only" mode:
+
+```
+pg_dump --dbname=$dbname --host=$host --port=$port --no-owner --no-privileges --schema-only --no-security-labels
+```
+
+Write to a file named `schema.sql`.
+
+## Recompile the datamodels
+
+You'll need Postgres installed locally with `psql` in your `$PATH` and the [prisma-render](https://github.com/prisma/prisma-render) CLI in your `$PATH`.
+
+Then run:
+
+```sh
+git clone https://github.com/prisma/database-schema-examples
+cd database-schema-examples
+make
+```
+
+If you don't have Postgres installed locally or you want to load these schemas into a remote Postgres instance, you can use the environment variable PG_URL=postgres://<remote-url>
+
+```sh
+PG_URL=postgres://... make
+```
+

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Useful whenever we need a real world example. Each example folder contains a `RE
 
 Here is a collection of instructions for different database systems:
 
-- [PostgreSQL](postgres)
+- [PostgreSQL](POSTGRES.md)

--- a/README.md
+++ b/README.md
@@ -1,34 +1,11 @@
 # Database Schema Examples
 
-This repository contains a bunch of examples for database schemas. Useful whenever we need a real world example. Each example folder contains a readme that contains the link to the original source of the example. It also mentions what changes had to be applied to the original source.
+This repository contains a bunch of examples for database schemas. 
 
-## Postgres
+Useful whenever we need a real world example. Each example folder contains a `README.md` that contains the link to the original source of the example. It also mentions changes that were applied compared to the original source.
 
-### Getting a database dump
+## Instructions
 
-Use `pg_dump` in "schema-only" mode:
+Here is a collection of instructions for different database systems:
 
-```
-pg_dump --dbname=$dbname --host=$host --port=$port --no-owner --no-privileges --schema-only --no-security-labels
-```
-
-Write to a file named `schema.sql`.
-
-## Recompile the datamodels
-
-You'll need Postgres installed locally with `psql` in your `$PATH` and the [prisma-render](https://github.com/prisma/prisma-render) CLI in your `$PATH`.
-
-Then run:
-
-```sh
-git clone https://github.com/prisma/database-schema-examples
-cd database-schema-examples
-make
-```
-
-If you don't have Postgres installed locally or you want to load these schemas into a remote Postgres instance, you can use the environment variable PG_URL=postgres://<remote-url>
-
-```sh
-PG_URL=postgres://... make
-```
-
+- [PostgreSQL](postgres)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Database Schema Examples
 
-This repository contains a bunch of examples for database schemas. 
+This repository contains a bunch of examples for database schemas, grouped by database. Useful whenever we need a real world example. 
 
-Useful whenever we need a real world example. Each example folder contains a `README.md` that contains the link to the original source of the example. It also mentions changes that were applied compared to the original source.
+Each example folder contains a `README.md` that contains the link to the original source of the example. It also mentions changes that were applied compared to the original source.
 
 ## Instructions
 


### PR DESCRIPTION
Simplify the README and put the Postgres instructions into their own file.